### PR TITLE
secure DOIs

### DIFF
--- a/src/main/webapp/WEB-INF/spring/link.properties.template
+++ b/src/main/webapp/WEB-INF/spring/link.properties.template
@@ -1,1 +1,1 @@
-link.handleProxy=http://dx.doi.org
+link.handleProxy=https://doi.org


### PR DESCRIPTION
According to https://www.doi.org/doi_handbook/3_Resolution.html#3.8 dx.doi.org is no longer preferred and since https is supported, I suggest to go the whole way ;-)